### PR TITLE
Async Sotawatch fetch, iOS friendly DHCP, dependency update

### DIFF
--- a/fw/data/script.js
+++ b/fw/data/script.js
@@ -660,12 +660,9 @@ function json_spots_to_table(num_spots, col_names, table_id) {
    thead.appendChild(tr); // Append the header row to the header
    table.append(tr) // Append the header to the table
 
-  try {
-    var req = new XMLHttpRequest(); // a new request
-    req.open("GET", url_string, false);
-    req.send(null);
-    var json_obj = JSON.parse(req.responseText);
-     
+   fetch(url_string)
+   .then(response => response.json())
+   .then(json_obj => {
      // Loop through the JSON data and create table rows
      json_obj.forEach((item) => {
         var tr = document.createElement("tr");
@@ -720,9 +717,7 @@ function json_spots_to_table(num_spots, col_names, table_id) {
 
         tr.appendChild(td);
 
-
         table.appendChild(tr);
-        
      });
 
     // clear the container
@@ -733,9 +728,8 @@ function json_spots_to_table(num_spots, col_names, table_id) {
      container.appendChild(table) // Append the table to the container element
 
      spot_fetch_errors = 0;
-
-  }
-  catch {
+   })
+   .catch(error => {
     spot_fetch_errors += 1;
 
     // allow up to 5 failures to fetch spots before showing the failure
@@ -749,7 +743,7 @@ function json_spots_to_table(num_spots, col_names, table_id) {
       p.appendChild(p_text)
       container.appendChild(p)
     }
-  }
+   });
 
 }
 

--- a/fw/platformio.ini
+++ b/fw/platformio.ini
@@ -87,7 +87,7 @@ lib_deps =
 	etherkit/Etherkit Si5351 @ 2.1.4
 	https://github.com/pschatzmann/arduino-audio-tools.git#v0.9.8
 	https://github.com/pschatzmann/arduino-audio-driver.git#f9038d6de5039e948daa93656581634a682f4f92
-	me-no-dev/ESP Async WebServer@^1.2.4
+	https://github.com/ESP32Async/ESPAsyncWebServer.git
 	https://github.com/PaulStoffregen/Time.git@^1.6.1
 	bblanchon/ArduinoJson@^7.2.0
 	https://github.com/holgerlembke/ESPxWebFlMgr.git

--- a/fw/src/server.cpp
+++ b/fw/src/server.cpp
@@ -135,13 +135,13 @@ void server_print_request(AsyncWebServerRequest *request) {
     int headers = request->headers();
     int i;
     for(i=0;i<headers;i++){
-        AsyncWebHeader* h = request->getHeader(i);
+        const AsyncWebHeader* h = request->getHeader(i);
         Serial.printf("_HEADER[%s]: %s\n", h->name().c_str(), h->value().c_str());
     }
 
     int params = request->params();
     for(i=0;i<params;i++){
-        AsyncWebParameter* p = request->getParam(i);
+        const AsyncWebParameter* p = request->getParam(i);
         if(p->isFile()){
             Serial.printf("_FILE[%s]: %s, size: %u\n", p->name().c_str(), p->value().c_str(), p->size());
         } else if(p->isPost()){

--- a/fw/src/wifi_conn.cpp
+++ b/fw/src/wifi_conn.cpp
@@ -48,7 +48,7 @@ void wifi_init() {
 
         // set up AP with hardcoded 192.168.1.1 address
         WiFi.mode(WIFI_AP);
-        WiFi.softAPConfig(IPAddress(192, 168, 1, 1), IPAddress(192, 168, 1, 1), IPAddress(255, 255, 255, 0));
+        WiFi.softAPConfig(IPAddress(192, 168, 1, 1), IPAddress(0, 0, 0, 0), IPAddress(255, 255, 255, 0));
         WiFi.softAP(fs_load_setting(PREFERENCE_FILE, "ap_ssid"), fs_load_setting(PREFERENCE_FILE, "ap_password"), 11);
         ip = WiFi.softAPIP();
     }


### PR DESCRIPTION
Resolves UI freeze while stopwatch loads slow over cellular
No need to configure IP manually in iOS - not tested on Android (0.0.0.0 default gateway)
Fixed the now broken ESPAsyncWebServer dependency